### PR TITLE
[Fix] 저장된 질문 삭제연동을 위한 API 수정

### DIFF
--- a/src/main/java/com/umc9th/areumdap/domain/user/dto/response/UserQuestionResponse.java
+++ b/src/main/java/com/umc9th/areumdap/domain/user/dto/response/UserQuestionResponse.java
@@ -9,15 +9,25 @@ import java.util.List;
 public record UserQuestionResponse(
         Long userQuestionId,
         Long questionId,
+        Long userChatThreadId,
         String content,
         Tag tag,
         LocalDateTime createdAt
 ) {
 
     public static UserQuestionResponse from(UserQuestion userQuestion) {
+
+        Long chatThreadId = null;
+
+        if (userQuestion.getChatHistory() != null &&
+                userQuestion.getChatHistory().getUserChatThread() != null) {
+            chatThreadId = userQuestion.getChatHistory().getUserChatThread().getId();
+        }
+
         return new UserQuestionResponse(
                 userQuestion.getId(),
                 userQuestion.getQuestionBank().getId(),
+                chatThreadId,
                 userQuestion.getContent(),
                 userQuestion.getTag(),
                 userQuestion.getCreatedAt()


### PR DESCRIPTION
## #️⃣ 관련 이슈
<!---- 자신이 완료한 이슈를 닫아주세요 -->
closed #101  //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🧩 작업 내용
저장된 질문 조회시 UserChatThreadId 가 추가되도록 수정하였고 UserChatThreadId 가 null safe하게 수정했습니다.

<img width="1383" height="460" alt="image" src="https://github.com/user-attachments/assets/626f61b1-2c3b-41f9-bda1-8d159776a4d6" />


📣 **To Reviewers**
---
<!-- 전달사항 -->

지금까지 저장된 userQuestion db 에 chat_history_id 가 null 로 되었지만 이젠 해당하는 값들이 입력됩니다. 

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 질문 응답에 채팅 스레드 식별자 정보가 추가되었습니다. 질문과 해당 채팅 이력을 더욱 명확하게 연결할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->