### PR TITLE
[Fix] 저장된 질문 삭제 api 구현

### DIFF
--- a/src/main/java/com/umc9th/areumdap/common/status/SuccessStatus.java
+++ b/src/main/java/com/umc9th/areumdap/common/status/SuccessStatus.java
@@ -58,6 +58,7 @@ public enum SuccessStatus implements BaseStatus {
      *  Question
      */
     CREATE_QUESTION_SUCCESS(HttpStatus.CREATED,"QUES_201","질문 저장 성공"),
+    DELETE_QUESTION_SUCCESS(HttpStatus.OK,"QUES_200","저장된 질문 삭제 성공"),
     GET_ALL_SAVED_QUESTION_SUCCESS(HttpStatus.OK,"QUES_200","저장된 질문 조회 성공"),
 
     /**

--- a/src/main/java/com/umc9th/areumdap/domain/question/controller/UserQuestionController.java
+++ b/src/main/java/com/umc9th/areumdap/domain/question/controller/UserQuestionController.java
@@ -45,4 +45,14 @@ public class UserQuestionController implements UserQuestionControllerDocs {
         );
     }
 
+    @Override
+    @DeleteMapping("/{userQuestionId}")
+    public ResponseEntity<ApiResponse<Void>> deleteQuestion(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long userQuestionId
+    ) {
+        userQuestionCommandService.deleteUserQuestion(userId, userQuestionId);
+        return ApiResponse.success(SuccessStatus.DELETE_QUESTION_SUCCESS, null);
+    }
+
 }

--- a/src/main/java/com/umc9th/areumdap/domain/question/controller/docs/UserQuestionControllerDocs.java
+++ b/src/main/java/com/umc9th/areumdap/domain/question/controller/docs/UserQuestionControllerDocs.java
@@ -28,7 +28,7 @@ public interface UserQuestionControllerDocs {
             summary = "저장한 질문 목록 조회 (커서 페이징)",
             description = """
                     커서 기반 무한 스크롤 방식으로 저장한 질문 목록을 조회합니다.
-                    
+
                     - 첫 요청: cursorTime, cursorId 없이 호출
                     - 다음 요청: 이전 응답의 nextCursorTime, nextCursorId를 그대로 전달
                     """
@@ -36,6 +36,16 @@ public interface UserQuestionControllerDocs {
     ResponseEntity<ApiResponse<UserQuestionCursorResponse>> getAllSavedQuestion(
             @AuthenticationPrincipal Long userId,
             @Valid @ModelAttribute CursorRequest request
+    );
+
+    @DeleteMapping("/{userQuestionId}")
+    @Operation(
+            summary = "저장된 질문 삭제",
+            description = "사용자가 저장한 질문을 삭제합니다. 대화에 사용 중인 질문은 목록에서 숨김 처리됩니다."
+    )
+    ResponseEntity<ApiResponse<Void>> deleteQuestion(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long userQuestionId
     );
 
 }

--- a/src/main/java/com/umc9th/areumdap/domain/user/entity/UserQuestion.java
+++ b/src/main/java/com/umc9th/areumdap/domain/user/entity/UserQuestion.java
@@ -64,4 +64,12 @@ public class UserQuestion extends BaseEntity {
         this.chatHistory = null;
     }
 
+    public void markAsUnsaved() {
+        this.saved = false;
+    }
+
+    public void clearParentQuestion() {
+        this.parentQuestion = null;
+    }
+
 }

--- a/src/main/java/com/umc9th/areumdap/domain/user/repository/UserQuestionRepository.java
+++ b/src/main/java/com/umc9th/areumdap/domain/user/repository/UserQuestionRepository.java
@@ -6,12 +6,17 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserQuestionRepository extends JpaRepository<UserQuestion,Long> {
 
     boolean existsByUser_IdAndChatHistory_Id(Long userId, Long chatHistoryId);
 
     List<UserQuestion> findByChatHistory_UserChatThread_Id(Long threadId);
+
+    Optional<UserQuestion> findByIdAndUser_IdAndSavedTrue(Long id, Long userId);
+
+    List<UserQuestion> findByParentQuestion_Id(Long parentQuestionId);
 
     @Modifying
     @Query("""


### PR DESCRIPTION
## #️⃣ 관련 이슈
<!---- 자신이 완료한 이슈를 닫아주세요 -->
closed #122  //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🧩 작업 내용
- 사용자가 저장한 질문(UserQuestion)을 삭제하는 DELETE /api/questions/{userQuestionId} API 추가                                                                       
- 대화 스레드에 사용 중인 질문은 FK 제약 보호를 위해 saved=false 논리 삭제 처리
- 미사용 질문은 자식 질문 참조 해제 후 물리 삭제 처리

   - saved=true, used=false : 자식 질문 parentQuestion null 처리 → 물리 삭제
   - saved=true, used=true : saved=false로 변경 (논리 삭제, 목록에서 숨김)

## 📸 스크린샷(선택)
<img width="1592" height="823" alt="image" src="https://github.com/user-attachments/assets/7135e5a1-a85d-4d30-83aa-92c65e27e066" />
<img width="726" height="265" alt="image" src="https://github.com/user-attachments/assets/0868ce92-c213-4428-b808-7d3d0c517fce" />

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 사용자가 저장한 질문을 삭제할 수 있는 기능을 추가했습니다. 삭제 시 소유권을 확인하고, 다른 질문과 연관된 경우 상태를 자동으로 조정합니다. 새로운 API 엔드포인트를 통해 질문 관리 기능이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->